### PR TITLE
fix: link & cropper bug

### DIFF
--- a/src/UBB/handlerHub/specificTagHandlers/url.tsx
+++ b/src/UBB/handlerHub/specificTagHandlers/url.tsx
@@ -8,6 +8,8 @@ import URL from 'url-parse'
 // Avoid XSS:
 // https://medium.com/javascript-security/avoiding-xss-in-react-is-still-hard-d2b5c7ad9412
 export function isSafe(dangerousURL: string) {
+  // Internal link
+  if (dangerousURL.length && dangerousURL[0] === '/') return true
   const url = URL(dangerousURL.trim(), {})
   if (url.protocol === 'http:') return true
   if (url.protocol === 'https:') return true

--- a/src/pages/UserCenter/Edit/LocalAvatarBox.tsx
+++ b/src/pages/UserCenter/Edit/LocalAvatarBox.tsx
@@ -29,14 +29,14 @@ interface Props {
 export default ({ imgSrc, uploadAvatorCallback }: Props) => {
   const [isLoading, setIsLoading] = useState(false)
   const cropRef = useRef<{
-    cropper: Cropper
+    getCropper: () => Cropper
   }>(null)
 
   const submitHandle = () => {
     if (!cropRef.current) {
       return
     }
-    const cropper = cropRef.current.cropper
+    const cropper = cropRef.current.getCropper()
 
     setIsLoading(true)
     const canvas = cropper.getCroppedCanvas()

--- a/src/pages/UserCenter/Edit/ReactCropper/index.tsx
+++ b/src/pages/UserCenter/Edit/ReactCropper/index.tsx
@@ -28,7 +28,7 @@ const ReactCropper: React.FC<Props> = (props, ref) => {
   }, [])
 
   useImperativeHandle(ref, () => ({
-    cropper: cropper.current,
+    getCropper: () => cropper.current,
   }))
 
   return (


### PR DESCRIPTION
1. UBB module can't parse internal link like `/topic/****` correctly.
2. Code `const cropper = cropRef.current.cropper` may cause `cropper` be `undefined`, so use the method of getting the attribute value instead of get the attribute value directly.